### PR TITLE
Omitempty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ matrix:
   fast_finish: true
 install: true
 script: ci/build.sh
-jdk: oraclejdk8
+jdk: openjdk8
 before_install: gem install bundler -v '< 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+ - feature: Added 'omitempty' feature to remove fields with default or null values
+
 ## 3.4.0
  - Added ability to directly convert from integer and float to boolean [#127](https://github.com/logstash-plugins/logstash-filter-mutate/pull/127)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.4.1
+## 3.5.1
  - feature: Added 'omitempty' feature to remove fields with default or null values
 
 ## 3.4.0

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ Contributors:
 * Tal Levy (talevy)
 * piavlo
 * Abdul Haseeb Hussain (AbdulHaseebHussain)
+* Gregory Ferreux (gferreux)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -83,6 +83,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-update>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-uppercase>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-capitalize>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -371,6 +372,15 @@ Example:
         capitalize => [ "fieldname" ]
       }
     }
+
+[id="plugins-{type}s-{plugin}-tag_on_failure"]
+===== `tag_on_failure`
+
+  * Value type is <<string,string>>
+  * The default value for this setting is `_mutate_error`
+
+If a failure occurs during the application of this mutate filter, the rest of
+the operations are aborted and the provided tag is added to the event.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -51,7 +51,7 @@ Example:
 -----
 filter {
     mutate {
-        split => ["hostname", "."]
+        split => { "hostname" => "." }
         add_field => { "shortHostname" => "%{hostname[0]}" }
     }
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -207,6 +207,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   #     }
   config :copy, :validate => :hash
 
+  # Tag to apply if the operation errors
+  config :tag_on_failure, :validate => :string, :default => '_mutate_error'
+
   TRUE_REGEX = (/^(true|t|yes|y|1|1.0)$/i).freeze
   FALSE_REGEX = (/^(false|f|no|n|0|0.0)$/i).freeze
   CONVERT_PREFIX = "convert_".freeze
@@ -262,6 +265,11 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     copy(event) if @copy
 
     filter_matched(event)
+  rescue => ex
+    meta = { :exception => ex.message }
+    meta[:backtrace] = ex.backtrace if logger.debug?
+    logger.warn('Exception caught while applying mutate filter', meta)
+    event.tag(@tag_on_failure)
   end
 
   private

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -207,6 +207,17 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   #     }
   config :copy, :validate => :hash
 
+  # Omit a variable if it as a default value.
+  #
+  # Example:
+  # [source,ruby]
+  #     filter {
+  #       mutate {
+  #         omitempty => [ "fieldname" ]
+  #       }
+  #     }
+  config :omitempty, :validate => :array
+
   TRUE_REGEX = (/^(true|t|yes|y|1|1.0)$/i).freeze
   FALSE_REGEX = (/^(false|f|no|n|0|0.0)$/i).freeze
   CONVERT_PREFIX = "convert_".freeze
@@ -260,6 +271,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     join(event) if @join
     merge(event) if @merge
     copy(event) if @copy
+    omitempty(event) if @omitempty
 
     filter_matched(event)
   end
@@ -463,6 +475,26 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
         original
       end
       event.set(field, result)
+    end
+  end
+
+  def omitempty(event)
+    @omitempty.each do |field|
+      original = event.get(field)
+      if original.nil?
+        event.remove(field)
+        next
+      end
+      result = case original
+               when String, Array, Hash
+                 original.empty? ? nil : original
+               when Integer
+                 original == 0 ? nil : original
+               else
+                 @logger.debug? && @logger.debug("Can't omitempty something that isn't a string,array,hash,integer", :field => field, :value => original)
+                 original
+               end
+      event.remove(field) if result.nil?
     end
   end
 

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.4.0'
+  s.version         = '3.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.4.0'
+  s.version         = '3.5.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -25,7 +25,6 @@ end
 
 logstash_version = Gem::Version.create(LOGSTASH_CORE_VERSION)
 
-# 
 if (Gem::Requirement.create('~> 7.0').satisfied_by?(logstash_version) ||
    (Gem::Requirement.create('~> 6.4').satisfied_by?(logstash_version) && LogStash::SETTINGS.get('config.field_reference.parser') == 'STRICT'))
   describe LogStash::Filters::Mutate do

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -23,6 +23,57 @@ module LogStash::Environment
   end
 end
 
+logstash_version = Gem::Version.create(LOGSTASH_CORE_VERSION)
+
+# 
+if (Gem::Requirement.create('~> 7.0').satisfied_by?(logstash_version) ||
+   (Gem::Requirement.create('~> 6.4').satisfied_by?(logstash_version) && LogStash::SETTINGS.get('config.field_reference.parser') == 'STRICT'))
+  describe LogStash::Filters::Mutate do
+    let(:config) { Hash.new }
+    subject(:mutate_filter) { LogStash::Filters::Mutate.new(config) }
+
+    before(:each) { mutate_filter.register }
+
+    let(:event) { LogStash::Event.new(attrs) }
+
+    context 'when operation would cause an error' do
+
+      let(:invalid_field_name) { "[[][[[[]message" }
+      let(:config) do
+        super().merge("add_field" => {invalid_field_name => "nope"})
+      end
+
+      shared_examples('catch and tag error') do
+        let(:expected_tag) { '_mutate_error' }
+
+        let(:event) { LogStash::Event.new({"message" => "foo"})}
+
+        context 'when the event is filtered' do
+          before(:each) { mutate_filter.filter(event) }
+          it 'does not raise an exception' do
+            # noop
+          end
+
+          it 'tags the event with the expected tag' do
+            expect(event).to include('tags')
+            expect(event.get('tags')).to include(expected_tag)
+          end
+        end
+      end
+
+      context 'when `tag_on_failure` is not provided' do
+        include_examples 'catch and tag error'
+      end
+
+      context 'when `tag_on_failure` is provided' do
+        include_examples 'catch and tag error' do
+          let(:expected_tag) { 'my_custom_tag' }
+          let(:config) { super().merge('tag_on_failure' => expected_tag) }
+        end
+      end
+    end
+  end
+end
 
 describe LogStash::Filters::Mutate do
 

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -1038,4 +1038,45 @@ describe LogStash::Filters::Mutate do
     end
   end
 
+  describe "omitempty" do
+
+    config <<-CONFIG
+      filter {
+        mutate {
+          omitempty => ["field"]
+        }
+      }
+    CONFIG
+
+    context 'when field is a string' do
+      sample({'field' => ''}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is an integer' do
+      sample({'field' => 0}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is an empty hash' do
+      sample({'field' => {}}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is an empty array' do
+      sample({'field' => []}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is null' do
+      sample({'field' => nil}) do
+        expect(subject).not_to include("field")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Add an operation called 'omitempty' to remove fields with null or default values.
(works with string "", integer 0, array [], hashes {}, and null values.)

````
filter {
        mutate {
          omitempty => ["field"]
        }
      }
````
will remove field if field = "", 0, [], {} or null
